### PR TITLE
Fix deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,9 @@
     "react-soundplayer": "^0.3.5",
     "redux": "~3.5.2",
     "redux-thunk": "~2.0.1",
-    "rxjs": "^5.0.0-beta.10"
+    "resolve-url": "^0.2.1",
+    "rx": "^4.1.0",
+    "rxjs": "^5.0.0-beta.10",
+    "three": "^0.78.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-addons-test-utils": "~15.0.2",
     "react-transform-hmr": "~1.0.4",
     "redux-logger": "^2.6.1",
+    "resolve-url-loader": "^1.6.0",
     "sass-loader": "~3.2.0",
     "sinon": "~1.17.4",
     "style-loader": "~0.13.1",


### PR DESCRIPTION
Closes #16.

Now the `package.json` contains all the dependencies needed to `npm start`.
